### PR TITLE
allow custom mqtt url/credentials

### DIFF
--- a/fireboard2mqtt/CHANGELOG.md
+++ b/fireboard2mqtt/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [3.1.0](https://github.com/gordlea/fireboard2mqtt/compare/v3.0.0...v3.1.0) (2024-03-26)
+
+Update to fireboard2mqtt v3.1.0
+
+Add ability to override mqtt url/username/password in home-assistant.
+
+Special thanks to @efaden for the pull request.
+
 ## [3.0.0](https://github.com/gordlea/fireboard2mqtt/compare/v2.0.5...v3.0.0) (2024-03-24)
 
 

--- a/fireboard2mqtt/Dockerfile
+++ b/fireboard2mqtt/Dockerfile
@@ -11,7 +11,7 @@ RUN apk add --no-cache \
     openssl-dev
 
 RUN cd /tmp && \
-    curl -sL https://github.com/gordlea/fireboard2mqtt/archive/refs/tags/v3.0.0.zip --output fb2mqtt.zip && \    
+    curl -sL https://github.com/gordlea/fireboard2mqtt/archive/refs/tags/v3.1.0.zip --output fb2mqtt.zip && \    
     unzip fb2mqtt.zip && \
     mv fireboard2mqtt* fireboard2mqtt && \
     cd /tmp/fireboard2mqtt* && \

--- a/fireboard2mqtt/config.yaml
+++ b/fireboard2mqtt/config.yaml
@@ -1,5 +1,5 @@
 name: Fireboard 2 MQTT
-version: 3.0.0
+version: 3.1.0
 stage: experimental
 slug: fireboard2mqtt
 url: https://github.com/gordlea/fireboard2mqtt
@@ -28,8 +28,9 @@ schema:
   fireboardAccount_email: str
   fireboardAccount_password: password
   fireboard_enable_drive: bool
-  mqtt_host: "str?"
-  mqtt_port: "int(1,65535)?"
+  override_mqtt_url: "str?"
+  override_mqtt_username: "str?"
+  override_mqtt_password: "password?"
   mqtt_discovery_prefix: "str?"
   mqtt_base_topic: "str?"
   mqtt_clientid: "str?"

--- a/fireboard2mqtt/config.yaml
+++ b/fireboard2mqtt/config.yaml
@@ -28,6 +28,8 @@ schema:
   fireboardAccount_email: str
   fireboardAccount_password: password
   fireboard_enable_drive: bool
+  mqtt_host: "str?"
+  mqtt_port: "int(1,65535)?"
   mqtt_discovery_prefix: "str?"
   mqtt_base_topic: "str?"
   mqtt_clientid: "str?"

--- a/fireboard2mqtt/run.sh
+++ b/fireboard2mqtt/run.sh
@@ -4,43 +4,45 @@ export RUST_LOG="$(bashio::config 'logLevel')"
 export FB2MQTT_FIREBOARDACCOUNT_EMAIL="$(bashio::config 'fireboardAccount_email')"
 export FB2MQTT_FIREBOARDACCOUNT_PASSWORD="$(bashio::config 'fireboardAccount_password')"
 
-# bashio::log.info "email: ${FB2MQTT_FIREBOARDACCOUNT_EMAIL}"
-# bashio::log.info "password: ${FB2MQTT_FIREBOARDACCOUNT_PASSWORD}"
-
 export FB2MQTT_FIREBOARD_ENABLE_DRIVE="$(bashio::config 'fireboard_enable_drive')"
+bashio::log.info "drive enabled: ${FB2MQTT_FIREBOARD_ENABLE_DRIVE}"
 
-export FB2MQTT_MQTT_USERNAME=$(bashio::services mqtt "username")
-export FB2MQTT_MQTT_PASSWORD=$(bashio::services mqtt "password")
+# If the user has supplied any override mqtt settings, use them, otherwise
+# use the mqtt service settings from home-assistant
+if bashio::config.has_value 'override_mqtt_username'; then
+    export FB2MQTT_MQTT_USERNAME="$(bashio::config 'override_mqtt_username')"
+    bashio::log.info "found user supplied override_mqtt_username: ${FB2MQTT_MQTT_USERNAME}"
+else
+    export FB2MQTT_MQTT_USERNAME=$(bashio::services mqtt "username")
+    bashio::log.info "using mqtt service username from home-assistant: ${FB2MQTT_MQTT_USERNAME}"
+fi 
 
-MQTT_HOST="$(bashio::config 'mqtt_host')"
-MQTT_PORT="$(bashio::config 'mqtt_port')"
-if [ -z "$MQTT_HOST" ]; then
+if bashio::config.has_value 'override_mqtt_password'; then
+    export FB2MQTT_MQTT_PASSWORD="$(bashio::config 'override_mqtt_password')"
+    bashio::log.info "found user supplied override_mqtt_password"
+else
+    export FB2MQTT_MQTT_PASSWORD=$(bashio::services mqtt "password")
+    bashio::log.info "using mqtt service password from home-assistant"
+fi
+
+if bashio::config.has_value 'override_mqtt_url'; then
+    export FB2MQTT_MQTT_URL="$(bashio::config 'override_mqtt_url')"
+    bashio::log.info "found user supplied override_mqtt_url: ${FB2MQTT_MQTT_URL}"
+else
     MQTT_HOST=$(bashio::services mqtt "host")
-fi
-
-if [ -z "$MQTT_PORT" ]; then
     MQTT_PORT=$(bashio::services mqtt "port")
+    MQTT_URL_PROTOCOL="mqtt"
+    if bashio::var.true "$(bashio::services mqtt "ssl")"; then
+        MQTT_URL_PROTOCOL="mqtts"
+    fi
+    export FB2MQTT_MQTT_URL="${MQTT_URL_PROTOCOL}://${MQTT_HOST}:${MQTT_PORT}"
+    bashio::log.info "using mqtt service url from home-assistant: ${FB2MQTT_MQTT_URL}"
 fi
-
-MQTT_URL_PROTOCOL="mqtt"
-if bashio::var.true "$(bashio::services mqtt "ssl")"; then
-    MQTT_URL_PROTOCOL="mqtts"
-fi
-
-if bashio::var.true "$(bashio::config  "rust_backtrace")"; then
-    export RUST_BACKTRACE=full
-fi
-
-
-export FB2MQTT_MQTT_URL="${MQTT_URL_PROTOCOL}://${MQTT_HOST}:${MQTT_PORT}"
-
-bashio::log.info "${FB2MQTT_MQTT_URL}"
 
 export FB2MQTT_DISCOVERY_PREFIX="$(bashio::config 'mqtt_discovery_prefix')"
 export FB2MQTT_MQTT_BASE_TOPIC="$(bashio::config 'mqtt_base_topic')"
 export FB2MQTT_MQTT_CLIENTID="$(bashio::config 'mqtt_clientid')"
 
 bashio::log.info "Starting fireboard2mqtt"
-bashio::log.info "drive enabled: ${FB2MQTT_FIREBOARD_ENABLE_DRIVE}"
 
 fireboard2mqtt

--- a/fireboard2mqtt/run.sh
+++ b/fireboard2mqtt/run.sh
@@ -12,8 +12,15 @@ export FB2MQTT_FIREBOARD_ENABLE_DRIVE="$(bashio::config 'fireboard_enable_drive'
 export FB2MQTT_MQTT_USERNAME=$(bashio::services mqtt "username")
 export FB2MQTT_MQTT_PASSWORD=$(bashio::services mqtt "password")
 
-MQTT_HOST=$(bashio::services mqtt "host")
-MQTT_PORT=$(bashio::services mqtt "port")
+MQTT_HOST="$(bashio::config 'mqtt_host')"
+MQTT_PORT="$(bashio::config 'mqtt_port')"
+if [ -z "$MQTT_HOST" ]; then
+    MQTT_HOST=$(bashio::services mqtt "host")
+fi
+
+if [ -z "$MQTT_PORT" ]; then
+    MQTT_PORT=$(bashio::services mqtt "port")
+fi
 
 MQTT_URL_PROTOCOL="mqtt"
 if bashio::var.true "$(bashio::services mqtt "ssl")"; then


### PR DESCRIPTION
Resolves gordlea/fireboard2mqtt#1

Adds 3 new optional config params:
```yml
  override_mqtt_url: "str?"
  override_mqtt_username: "str?"
  override_mqtt_password: "password?"
```

If any of these are specific, it will use them. If they are left blank, it will use the defaults supplied by home-assistant.

Special thanks to @efaden for the initial PR for this.